### PR TITLE
Fix c_formatter_42 command in formatter.lua

### DIFF
--- a/lua/42norm/formatter.lua
+++ b/lua/42norm/formatter.lua
@@ -15,7 +15,7 @@ function M.format()
 	end
 
 	-- Run the formatter command directly on the temporary file
-	local cmd = "python3 -m c_formatter_42 "
+	local cmd = "c_formatter_42 "
 	if vim.fn.has("win32") == 1 then
 		cmd = cmd .. temp_file .. " 2> NUL"
 	else


### PR DESCRIPTION
**Fix c_formatter_42 command by using direct command instead of python3 -m**

In my environment the `c_formatter_42` was available as a command on its own, but `python3 -m c_formatter_42` wasn't available, hence the plugin wasn't working for me.
At first, I thought that the problem is the way I installed, but my colleague who's on a different OS (I'm on macOS, they're on Linux) had the same problem.

For this reason, I propose merging this change into the repository. If not, I will maintain my fork alongside your repo - for myself, my colleague, and anyone who encounters the same problem.

Thanks in advance.

**Changes**

* Replaced `python3 -m c_formatter_42` command with the direct `c_formatter_42` command